### PR TITLE
Added "required" asterisks by default, in crud controller stub

### DIFF
--- a/stubs/crud-controller.stub
+++ b/stubs/crud-controller.stub
@@ -17,10 +17,20 @@ class __class_name__ extends CrudController
         | BASIC CRUD INFORMATION
         |--------------------------------------------------------------------------
         */
+        
         $this->crud->setModel(__model_class__::class);
         $this->crud->setRoute(config('backpack.base.route_prefix') . '/__route_name__');
         $this->crud->setEntityNameStrings(trans('models.__languagefile_key__.singular'), trans('models.__languagefile_key__.plural'));
 
+        /*
+        |--------------------------------------------------------------------------
+        | OPTIONAL CRUD SETTINGS
+        |--------------------------------------------------------------------------
+        */
+        
+        $this->crud->setRequiredFields(StoreRequest::class, 'create');
+        $this->crud->setRequiredFields(UpdateRequest::class, 'edit');
+        
         /*
         |--------------------------------------------------------------------------
         | CRUD COLUMNS
@@ -36,9 +46,6 @@ class __class_name__ extends CrudController
         */
 
         $this->crud->addFields(__fields__);
-
-        $this->crud->setRequiredFields(StoreRequest::class, 'create');
-        $this->crud->setRequiredFields(UpdateRequest::class, 'edit');
 
         /*
         |--------------------------------------------------------------------------

--- a/stubs/crud-controller.stub
+++ b/stubs/crud-controller.stub
@@ -37,6 +37,9 @@ class __class_name__ extends CrudController
 
         $this->crud->addFields(__fields__);
 
+        $this->crud->setRequiredFields(StoreRequest::class, 'create');
+        $this->crud->setRequiredFields(UpdateRequest::class, 'edit');
+
         /*
         |--------------------------------------------------------------------------
         | CRUD FILTERS


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Generated CrudControllers don't show asterisks for required attributes, despite the fact that we know the requests, and the request holds that information. 

## How has this been tested?

```php artisan make:entity dog --migrate --schema="first_name:string, last_name:string, nickname:string:nullable, age:integer, bio:text:nullable, extras:text:nullable"```

## Screenshots (if appropriate)

Seems to work fine:
![screenshot 2018-11-12 at 17 43 22](https://user-images.githubusercontent.com/1032474/48357967-811c3500-e6a2-11e8-8aaf-bac62a1d9270.png)



## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] I have added tests to cover my changes.
- [x] If my change requires a change to the documentation, I have updated it accordingly.
