### PR TITLE
Update crud-controller.stub for Backpack v4

### DIFF
--- a/stubs/crud-controller.stub
+++ b/stubs/crud-controller.stub
@@ -3,74 +3,40 @@
 namespace __class_namespace__;
 
 use Backpack\CRUD\app\Http\Controllers\CrudController;
+use Backpack\CRUD\app\Library\CrudPanel\CrudPanelFacade as CRUD;
 use __model_namespace__\__model_class__;
 use __request_namespace__\__request_class__ as StoreRequest;
 use __request_namespace__\__request_class__ as UpdateRequest;
 
 class __class_name__ extends CrudController
 {
+    use \Backpack\CRUD\app\Http\Controllers\Operations\ListOperation;
+    use \Backpack\CRUD\app\Http\Controllers\Operations\CreateOperation;
+    use \Backpack\CRUD\app\Http\Controllers\Operations\UpdateOperation;
+    use \Backpack\CRUD\app\Http\Controllers\Operations\DeleteOperation;
+    use \Backpack\CRUD\app\Http\Controllers\Operations\ShowOperation;
+    
     public function setup()
-    {
-
-        /*
-        |--------------------------------------------------------------------------
-        | BASIC CRUD INFORMATION
-        |--------------------------------------------------------------------------
-        */
-        
+    {   
         $this->crud->setModel(__model_class__::class);
         $this->crud->setRoute(config('backpack.base.route_prefix') . '/__route_name__');
         $this->crud->setEntityNameStrings(trans('models.__languagefile_key__.singular'), trans('models.__languagefile_key__.plural'));
-
-        /*
-        |--------------------------------------------------------------------------
-        | OPTIONAL CRUD SETTINGS
-        |--------------------------------------------------------------------------
-        */
-        
-        $this->crud->setRequiredFields(StoreRequest::class, 'create');
-        $this->crud->setRequiredFields(UpdateRequest::class, 'edit');
-        
-        /*
-        |--------------------------------------------------------------------------
-        | CRUD COLUMNS
-        |--------------------------------------------------------------------------
-        */
-
+    }
+    
+    protected function setupListOperation()
+    {
         $this->crud->addColumns(__columns__);
-
-        /*
-        |--------------------------------------------------------------------------
-        | CRUD FIELDS
-        |--------------------------------------------------------------------------
-        */
-
+    }
+    
+    protected function setupCreateOperation()
+    {
+        $this->crud->setValidation(StoreRequest::class);
+        
         $this->crud->addFields(__fields__);
-
-        /*
-        |--------------------------------------------------------------------------
-        | CRUD FILTERS
-        |--------------------------------------------------------------------------
-        */
-
-        //
     }
-
-    public function store(StoreRequest $request)
+    
+    protected function setupUpdateOperation()
     {
-        // your additional operations before save here
-        $redirect_location = parent::storeCrud($request);
-        // your additional operations after save here
-        // use $this->data['entry'] or $this->crud->entry
-        return $redirect_location;
-    }
-
-    public function update(UpdateRequest $request)
-    {
-        // your additional operations before save here
-        $redirect_location = parent::updateCrud($request);
-        // your additional operations after save here
-        // use $this->data['entry'] or $this->crud->entry
-        return $redirect_location;
+        $this->setupCreateOperation();
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Changes the ```crud-controller.stub``` to generate Backpack v4 controllers.

## Motivation and context

The package did not provide a way to generate Backpack v4 controllers.

## How has this been tested?

No, it has not! PLEASE DON'T MERGE THIS YET. Before we merge this we need:
- https://github.com/webfactor/laravel-generators/pull/39 to be merged;
- your reply on the matter below;

Another IMPORTANT problem with this PR is that **there's no ```backpack/crud``` requirement to ```webfactor/laravel-generators```**. This means that it _assumes_ the user is running a certain Backpack version that is compatible with the stub. The current PR assumes they're running Backpack v4, since that's the current version, that everybody is installing (Solution 1).

(Solution 2) A different way to approach this would be to have two controller stubs: ```crud3-controller.stub``` and ```crud4-controller.stub```, and before generating the crud controller, to see which Backpack version is installed and use the correct Stub. This is a little more complicated, but not too complicated. It would probably require adding a dependency ([ocramius/package-versions](https://github.com/Ocramius/PackageVersions)) to check the currently installed version. 

I don't know if it's really necessary though - why support Backpack 3.x when 4.x is here. What's you position on this? Solution 1 or Solution 2?

## Screenshots (if appropriate)

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

Please, please, please, don't send your pull request until all of the boxes are ticked. Once your pull request is created, it will trigger a build on our [continuous integration](http://www.phptherightway.com/#continuous-integration) server to make sure your [tests and code style pass](https://help.github.com/articles/about-required-status-checks/).

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [ ] I have added tests to cover my changes.
- [ ] If my change requires a change to the documentation, I have updated it accordingly.

If you're unsure about any of these, don't hesitate to ask. We're here to help!
